### PR TITLE
Add incident management handlers and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/incident_management/db.py
+++ b/incident_management/db.py
@@ -1,0 +1,74 @@
+import os
+import sqlite3
+from datetime import datetime
+
+DB_NAME = os.environ.get('INCIDENT_DB', 'incidents.db')
+
+
+def get_connection():
+    conn = sqlite3.connect(DB_NAME)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS incidents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                type TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                status TEXT NOT NULL,
+                description TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+
+
+def row_to_dict(row):
+    return {key: row[key] for key in row.keys()}
+
+
+def create_incident(data):
+    now = datetime.utcnow().isoformat()
+    with get_connection() as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO incidents (type, severity, status, description, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                data["type"],
+                data["severity"],
+                data["status"],
+                data.get("description"),
+                now,
+                now,
+            ),
+        )
+        incident_id = cursor.lastrowid
+        row = conn.execute("SELECT * FROM incidents WHERE id=?", (incident_id,)).fetchone()
+    return row_to_dict(row)
+
+
+def update_incident(incident_id, data):
+    fields = {k: data[k] for k in ["type", "severity", "status", "description"] if k in data}
+    if not fields:
+        return None
+    fields["updated_at"] = datetime.utcnow().isoformat()
+    set_clause = ", ".join(f"{k}=?" for k in fields)
+    values = list(fields.values())
+    values.append(incident_id)
+    with get_connection() as conn:
+        conn.execute(f"UPDATE incidents SET {set_clause} WHERE id=?", values)
+        row = conn.execute("SELECT * FROM incidents WHERE id=?", (incident_id,)).fetchone()
+    return row_to_dict(row) if row else None
+
+
+def get_incident(incident_id):
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM incidents WHERE id=?", (incident_id,)).fetchone()
+    return row_to_dict(row) if row else None

--- a/incident_management/handlers.py
+++ b/incident_management/handlers.py
@@ -1,0 +1,54 @@
+import json
+from . import db
+
+
+def create_incident(event, context=None):
+    db.init_db()
+    try:
+        body = json.loads(event.get("body", "{}"))
+    except json.JSONDecodeError:
+        return {"statusCode": 400, "body": json.dumps({"error": "Invalid JSON"})}
+
+    required = ["type", "severity", "status"]
+    missing = [f for f in required if f not in body]
+    if missing:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": f"Missing fields: {', '.join(missing)}"}),
+        }
+
+    incident = db.create_incident(body)
+    return {"statusCode": 201, "body": json.dumps(incident)}
+
+
+def update_incident(event, context=None):
+    db.init_db()
+    path = event.get("pathParameters") or {}
+    incident_id = path.get("id")
+    if not incident_id:
+        return {"statusCode": 400, "body": json.dumps({"error": "Missing id"})}
+
+    try:
+        body = json.loads(event.get("body", "{}"))
+    except json.JSONDecodeError:
+        return {"statusCode": 400, "body": json.dumps({"error": "Invalid JSON"})}
+
+    incident = db.update_incident(int(incident_id), body)
+    if not incident:
+        return {"statusCode": 404, "body": json.dumps({"error": "Incident not found"})}
+
+    return {"statusCode": 200, "body": json.dumps(incident)}
+
+
+def get_incident(event, context=None):
+    db.init_db()
+    path = event.get("pathParameters") or {}
+    incident_id = path.get("id")
+    if not incident_id:
+        return {"statusCode": 400, "body": json.dumps({"error": "Missing id"})}
+
+    incident = db.get_incident(int(incident_id))
+    if not incident:
+        return {"statusCode": 404, "body": json.dumps({"error": "Incident not found"})}
+
+    return {"statusCode": 200, "body": json.dumps(incident)}

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,69 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from incident_management import handlers, db
+
+
+class IncidentHandlerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        os.environ['INCIDENT_DB'] = self.tmp.name
+        db.init_db()
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def test_create_incident(self):
+        event = {
+            'body': json.dumps({
+                'type': 'Fall',
+                'severity': 'High',
+                'status': 'Open',
+                'description': 'Patient fell in hallway'
+            })
+        }
+        response = handlers.create_incident(event)
+        self.assertEqual(response['statusCode'], 201)
+        body = json.loads(response['body'])
+        self.assertEqual(body['type'], 'Fall')
+        self.assertEqual(body['status'], 'Open')
+
+    def test_update_and_get_incident(self):
+        create_event = {
+            'body': json.dumps({'type': 'Medication', 'severity': 'Low', 'status': 'Open'})
+        }
+        create_resp = handlers.create_incident(create_event)
+        created = json.loads(create_resp['body'])
+        incident_id = created['id']
+
+        update_event = {
+            'pathParameters': {'id': str(incident_id)},
+            'body': json.dumps({'status': 'Closed'})
+        }
+        update_resp = handlers.update_incident(update_event)
+        self.assertEqual(update_resp['statusCode'], 200)
+        updated = json.loads(update_resp['body'])
+        self.assertEqual(updated['status'], 'Closed')
+
+        get_event = {'pathParameters': {'id': str(incident_id)}}
+        get_resp = handlers.get_incident(get_event)
+        self.assertEqual(get_resp['statusCode'], 200)
+        retrieved = json.loads(get_resp['body'])
+        self.assertEqual(retrieved['status'], 'Closed')
+
+    def test_update_nonexistent(self):
+        update_event = {
+            'pathParameters': {'id': '999'},
+            'body': json.dumps({'status': 'Closed'})
+        }
+        update_resp = handlers.update_incident(update_event)
+        self.assertEqual(update_resp['statusCode'], 404)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement incident database helpers
- create serverless handlers to create, update and view incidents
- ignore cache files
- add unit tests for the handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d41a0d2c832fbfae4ddbc3bee408