### PR TITLE
Add risk register module with serverless handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # healthcare-saas-free
+
 Free serverless SaaS replicating Radar Healthcare's core modules (incident management, risk register, audit).
+
+## Risk Register Module
+
+This repository includes a simple risk register implemented with serverless functions. Each risk contains:
+
+- `riskId`: unique identifier
+- `description`: text description
+- `likelihood`: numeric likelihood value
+- `impact`: numeric impact value
+- `status`: textual status
+
+### Endpoints
+
+- `POST /risks` – create a new risk record
+- `PUT /risks/{riskId}` – update an existing risk record
+- `GET /risks/{riskId}` – retrieve a risk record
+
+### Local Development
+
+The risk data is stored in `data/risk-db.json`. The handlers can be executed locally using Node:
+
+```bash
+node handlers/createRisk.js
+```
+
+Unit tests can be run with:
+
+```bash
+npm test
+```

--- a/data/risk-db.json
+++ b/data/risk-db.json
@@ -1,0 +1,23 @@
+[
+  {
+    "riskId": "ad331f2a-369f-4496-8e6a-b27d96e65eee",
+    "description": "New risk",
+    "likelihood": 2,
+    "impact": 3,
+    "status": "open"
+  },
+  {
+    "riskId": "0829a99d-b1d9-4cc4-bc3a-5224dc40db34",
+    "description": "Risk",
+    "likelihood": 1,
+    "impact": 1,
+    "status": "closed"
+  },
+  {
+    "riskId": "7bcc7c86-48a3-4106-80c1-fd2cb4aec11a",
+    "description": "Another",
+    "likelihood": 1,
+    "impact": 1,
+    "status": "open"
+  }
+]

--- a/handlers/createRisk.js
+++ b/handlers/createRisk.js
@@ -1,0 +1,23 @@
+const { readRisks, writeRisks } = require('../riskData');
+const crypto = require('crypto');
+
+module.exports.createRisk = async (event) => {
+  const { description, likelihood, impact, status } = JSON.parse(event.body || '{}');
+  if (!description) {
+    return { statusCode: 400, body: 'Description is required' };
+  }
+  const risks = readRisks();
+  const risk = {
+    riskId: crypto.randomUUID(),
+    description,
+    likelihood,
+    impact,
+    status
+  };
+  risks.push(risk);
+  writeRisks(risks);
+  return {
+    statusCode: 201,
+    body: JSON.stringify(risk)
+  };
+};

--- a/handlers/getRisk.js
+++ b/handlers/getRisk.js
@@ -1,0 +1,17 @@
+const { readRisks } = require('../riskData');
+
+module.exports.getRisk = async (event) => {
+  const riskId = event.pathParameters && event.pathParameters.riskId;
+  if (!riskId) {
+    return { statusCode: 400, body: 'Risk ID is required' };
+  }
+  const risks = readRisks();
+  const risk = risks.find(r => r.riskId === riskId);
+  if (!risk) {
+    return { statusCode: 404, body: 'Risk not found' };
+  }
+  return {
+    statusCode: 200,
+    body: JSON.stringify(risk)
+  };
+};

--- a/handlers/updateRisk.js
+++ b/handlers/updateRisk.js
@@ -1,0 +1,21 @@
+const { readRisks, writeRisks } = require('../riskData');
+
+module.exports.updateRisk = async (event) => {
+  const riskId = event.pathParameters && event.pathParameters.riskId;
+  const updates = JSON.parse(event.body || '{}');
+  if (!riskId) {
+    return { statusCode: 400, body: 'Risk ID is required' };
+  }
+  const risks = readRisks();
+  const index = risks.findIndex(r => r.riskId === riskId);
+  if (index === -1) {
+    return { statusCode: 404, body: 'Risk not found' };
+  }
+  const updatedRisk = { ...risks[index], ...updates };
+  risks[index] = updatedRisk;
+  writeRisks(risks);
+  return {
+    statusCode: 200,
+    body: JSON.stringify(updatedRisk)
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "healthcare-saas-free",
+  "version": "1.0.0",
+  "description": "Free serverless SaaS replicating Radar Healthcare's core modules (incident management, risk register, audit).",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/riskData.js
+++ b/riskData.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const DB_FILE = process.env.RISK_DB || path.join(__dirname, 'data', 'risk-db.json');
+
+function readRisks() {
+  if (!fs.existsSync(DB_FILE)) {
+    return [];
+  }
+  const data = fs.readFileSync(DB_FILE, 'utf8');
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    return [];
+  }
+}
+
+function writeRisks(risks) {
+  fs.writeFileSync(DB_FILE, JSON.stringify(risks, null, 2));
+}
+
+module.exports = { readRisks, writeRisks, DB_FILE };

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,24 @@
+service: healthcare-saas-free
+provider:
+  name: aws
+  runtime: nodejs20.x
+  stage: dev
+functions:
+  createRisk:
+    handler: handlers/createRisk.createRisk
+    events:
+      - http:
+          path: risks
+          method: post
+  updateRisk:
+    handler: handlers/updateRisk.updateRisk
+    events:
+      - http:
+          path: risks/{riskId}
+          method: put
+  getRisk:
+    handler: handlers/getRisk.getRisk
+    events:
+      - http:
+          path: risks/{riskId}
+          method: get

--- a/tests/riskHandlers.test.js
+++ b/tests/riskHandlers.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const { createRisk } = require('../handlers/createRisk');
+const { updateRisk } = require('../handlers/updateRisk');
+const { getRisk } = require('../handlers/getRisk');
+
+let tempDb;
+
+beforeEach(() => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'risk-'));
+  tempDb = path.join(dir, 'db.json');
+  fs.writeFileSync(tempDb, '[]');
+  process.env.RISK_DB = tempDb;
+});
+
+afterEach(() => {
+  fs.unlinkSync(tempDb);
+  fs.rmdirSync(path.dirname(tempDb));
+  delete process.env.RISK_DB;
+});
+
+test('createRisk returns new risk', async () => {
+  const event = { body: JSON.stringify({ description: 'New risk', likelihood: 2, impact: 3, status: 'open' }) };
+  const res = await createRisk(event);
+  assert.strictEqual(res.statusCode, 201);
+  const risk = JSON.parse(res.body);
+  assert.ok(risk.riskId);
+  assert.strictEqual(risk.description, 'New risk');
+});
+
+test('updateRisk modifies existing risk', async () => {
+  const createEvent = { body: JSON.stringify({ description: 'Risk', likelihood: 1, impact: 1, status: 'open' }) };
+  const created = await createRisk(createEvent);
+  const risk = JSON.parse(created.body);
+  const updateEvent = { pathParameters: { riskId: risk.riskId }, body: JSON.stringify({ status: 'closed' }) };
+  const res = await updateRisk(updateEvent);
+  assert.strictEqual(res.statusCode, 200);
+  const updated = JSON.parse(res.body);
+  assert.strictEqual(updated.status, 'closed');
+});
+
+test('getRisk retrieves a risk by id', async () => {
+  const createEvent = { body: JSON.stringify({ description: 'Another', likelihood: 1, impact: 1, status: 'open' }) };
+  const created = await createRisk(createEvent);
+  const risk = JSON.parse(created.body);
+  const getEvent = { pathParameters: { riskId: risk.riskId } };
+  const res = await getRisk(getEvent);
+  assert.strictEqual(res.statusCode, 200);
+  const fetched = JSON.parse(res.body);
+  assert.strictEqual(fetched.riskId, risk.riskId);
+});


### PR DESCRIPTION
## Summary
- implement minimal serverless risk register
- create API handlers for creating, updating and retrieving risks
- store risk data in a JSON file
- configure serverless.yml
- add unit tests using `node:test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884d42bf250832f90ff3ce48f40a1d8

## Summary by Sourcery

Implement a serverless risk register module with create, update, and get handlers backed by a JSON file, add environment-based configuration, include unit tests, and update documentation.

New Features:
- Add risk register module with HTTP endpoints for creating, updating, and retrieving risks

Enhancements:
- Allow overriding the data file path via RISK_DB environment variable

Build:
- Configure serverless.yml for AWS functions
- Add test script to package.json

Documentation:
- Document the risk register module, endpoints, and local development in README

Tests:
- Add unit tests for risk handlers using Node's built-in test framework