### PR TITLE
Add audit management module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+audit/data/*.json
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # healthcare-saas-free
 Free serverless SaaS replicating Radar Healthcare's core modules (incident management, risk register, audit).
+
+## Audit Module
+
+The `audit` folder contains a lightweight serverless module with endpoints for:
+
+* `POST /audit/forms` - create an audit form with custom questions.
+* `PUT /audit/forms/{id}` - edit an existing form.
+* `POST /audit/schedule` - schedule an audit.
+* `POST /audit/results` - submit audit results, including offline capture support.
+* `POST /audit/sync` - sync offline results when back online.
+
+All data is stored locally in JSON files under `audit/data` for simplicity. Unit tests can be run with `npm test`.

--- a/audit/serverless.yml
+++ b/audit/serverless.yml
@@ -1,0 +1,35 @@
+service: audit-management
+provider:
+  name: aws
+  runtime: nodejs18.x
+functions:
+  createForm:
+    handler: src/createForm.handler
+    events:
+      - http:
+          path: audit/forms
+          method: post
+  editForm:
+    handler: src/editForm.handler
+    events:
+      - http:
+          path: audit/forms/{id}
+          method: put
+  scheduleAudit:
+    handler: src/scheduleAudit.handler
+    events:
+      - http:
+          path: audit/schedule
+          method: post
+  submitResults:
+    handler: src/submitResults.handler
+    events:
+      - http:
+          path: audit/results
+          method: post
+  syncOfflineResults:
+    handler: src/syncOfflineResults.handler
+    events:
+      - http:
+          path: audit/sync
+          method: post

--- a/audit/src/createForm.js
+++ b/audit/src/createForm.js
@@ -1,0 +1,14 @@
+const { getForms, saveForms } = require('./storage');
+
+exports.handler = async (event) => {
+  const body = JSON.parse(event.body || '{}');
+  const forms = getForms();
+  const id = Date.now().toString();
+  const form = { id, name: body.name || 'Untitled', questions: body.questions || [] };
+  forms.push(form);
+  saveForms(forms);
+  return {
+    statusCode: 201,
+    body: JSON.stringify(form)
+  };
+};

--- a/audit/src/editForm.js
+++ b/audit/src/editForm.js
@@ -1,0 +1,15 @@
+const { getForms, saveForms } = require('./storage');
+
+exports.handler = async (event) => {
+  const { id } = event.pathParameters || {};
+  const body = JSON.parse(event.body || '{}');
+  const forms = getForms();
+  const form = forms.find(f => f.id === id);
+  if (!form) {
+    return { statusCode: 404, body: 'Not Found' };
+  }
+  if (body.name !== undefined) form.name = body.name;
+  if (body.questions !== undefined) form.questions = body.questions;
+  saveForms(forms);
+  return { statusCode: 200, body: JSON.stringify(form) };
+};

--- a/audit/src/scheduleAudit.js
+++ b/audit/src/scheduleAudit.js
@@ -1,0 +1,16 @@
+const { getSchedule, saveSchedule } = require('./storage');
+
+exports.handler = async (event) => {
+  const body = JSON.parse(event.body || '{}');
+  const schedule = getSchedule();
+  const id = Date.now().toString();
+  const item = {
+    id,
+    formId: body.formId,
+    date: body.date,
+    assignedTo: body.assignedTo
+  };
+  schedule.push(item);
+  saveSchedule(schedule);
+  return { statusCode: 201, body: JSON.stringify(item) };
+};

--- a/audit/src/storage.js
+++ b/audit/src/storage.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const dataDir = path.join(__dirname, '..', 'data');
+const formsFile = path.join(dataDir, 'forms.json');
+const resultsFile = path.join(dataDir, 'results.json');
+const offlineFile = path.join(dataDir, 'offlineResults.json');
+const scheduleFile = path.join(dataDir, 'schedule.json');
+
+function readJson(file) {
+  if (!fs.existsSync(file)) {
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function writeJson(file, data) {
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+function getForms() {
+  return readJson(formsFile);
+}
+
+function saveForms(forms) {
+  writeJson(formsFile, forms);
+}
+
+function getResults() {
+  return readJson(resultsFile);
+}
+
+function saveResults(results) {
+  writeJson(resultsFile, results);
+}
+
+function getSchedule() {
+  return readJson(scheduleFile);
+}
+
+function saveSchedule(items) {
+  writeJson(scheduleFile, items);
+}
+
+function saveOffline(result) {
+  const offline = readJson(offlineFile);
+  offline.push(result);
+  writeJson(offlineFile, offline);
+}
+
+function syncOffline() {
+  const offline = readJson(offlineFile);
+  if (offline.length === 0) return;
+  const results = getResults();
+  results.push(...offline);
+  saveResults(results);
+  writeJson(offlineFile, []);
+}
+
+module.exports = {
+  getForms,
+  saveForms,
+  getResults,
+  saveResults,
+  getSchedule,
+  saveSchedule,
+  saveOffline,
+  syncOffline
+};

--- a/audit/src/submitResults.js
+++ b/audit/src/submitResults.js
@@ -1,0 +1,18 @@
+const { getResults, saveResults, saveOffline } = require('./storage');
+
+exports.handler = async (event) => {
+  const body = JSON.parse(event.body || '{}');
+  const result = {
+    formId: body.formId,
+    responses: body.responses,
+    timestamp: Date.now()
+  };
+  if (body.offline) {
+    saveOffline(result);
+    return { statusCode: 202, body: 'Stored offline' };
+  }
+  const results = getResults();
+  results.push(result);
+  saveResults(results);
+  return { statusCode: 201, body: JSON.stringify(result) };
+};

--- a/audit/src/syncOfflineResults.js
+++ b/audit/src/syncOfflineResults.js
@@ -1,0 +1,6 @@
+const { syncOffline } = require('./storage');
+
+exports.handler = async () => {
+  syncOffline();
+  return { statusCode: 200, body: 'Synced' };
+};

--- a/audit/test/createForm.test.js
+++ b/audit/test/createForm.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { handler } = require('../src/createForm');
+const dataDir = path.join(__dirname, '..', 'data');
+
+exports.run = async function() {
+  if (fs.existsSync(path.join(dataDir, 'forms.json'))) fs.unlinkSync(path.join(dataDir, 'forms.json'));
+  const event = { body: JSON.stringify({ name: 'Safety', questions: ['q1'] }) };
+  const resp = await handler(event);
+  assert.strictEqual(resp.statusCode, 201);
+  const forms = JSON.parse(fs.readFileSync(path.join(dataDir, 'forms.json')));
+  assert.strictEqual(forms.length, 1);
+  assert.strictEqual(forms[0].name, 'Safety');
+};

--- a/audit/test/run-tests.js
+++ b/audit/test/run-tests.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const testDir = __dirname;
+  const files = fs.readdirSync(testDir).filter(f => f.endsWith('.test.js'));
+  let failed = 0;
+  for (const file of files) {
+    const test = require(path.join(testDir, file));
+    try {
+      await test.run();
+      console.log(file + ': ok');
+    } catch (e) {
+      failed++;
+      console.error(file + ': fail');
+      console.error(e);
+    }
+  }
+  if (failed > 0) {
+    console.error(failed + ' tests failed');
+    process.exit(1);
+  } else {
+    console.log('All tests passed');
+  }
+})();

--- a/audit/test/storage.test.js
+++ b/audit/test/storage.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const storage = require('../src/storage');
+const dataDir = path.join(__dirname, '..', 'data');
+
+exports.run = async function() {
+  // clean files
+  for (const f of ['results.json', 'offlineResults.json']) {
+    const p = path.join(dataDir, f);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+  const result = { formId: '1', responses: ['a'] };
+  storage.saveOffline(result);
+  storage.syncOffline();
+  const results = storage.getResults();
+  assert.strictEqual(results.length, 1);
+  assert.strictEqual(results[0].formId, '1');
+  const offline = fs.readFileSync(path.join(dataDir, 'offlineResults.json'), 'utf8');
+  assert.strictEqual(offline.trim(), '[]');
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "healthcare-saas-free",
+  "version": "1.0.0",
+  "description": "Free serverless SaaS replicating Radar Healthcare's core modules (incident management, risk register, audit).",
+  "main": "index.js",
+  "scripts": {
+    "test": "node audit/test/run-tests.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- scaffold audit management microservice with serverless config
- implement endpoints for creating/editing forms, scheduling audits, and submitting results with offline sync
- store data in local JSON files via helper module
- add basic unit tests and custom test runner
- document audit module usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884d43c73c0832fae9fc9c88bd0a4b3