### PR TITLE
Add basic React frontend skeleton

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "healthcare-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.2"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Healthcare SaaS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import RiskRegister from './pages/RiskRegister';
+import AuditForm from './pages/AuditForm';
+
+const App: React.FC = () => {
+  return (
+    <div>
+      <nav>
+        <Link to="/risks">Risk Register</Link>
+        {' | '}
+        <Link to="/audits">Audits</Link>
+      </nav>
+      <Routes>
+        <Route path="/risks" element={<RiskRegister />} />
+        <Route path="/audits" element={<AuditForm />} />
+      </Routes>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import { BrowserRouter } from 'react-router-dom';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/pages/AuditForm.tsx
+++ b/frontend/src/pages/AuditForm.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+
+interface Audit {
+  id: string;
+  name: string;
+  findings: string;
+}
+
+const AuditForm: React.FC = () => {
+  const [audits, setAudits] = useState<Audit[]>([]);
+  const [name, setName] = useState('');
+  const [findings, setFindings] = useState('');
+
+  useEffect(() => {
+    fetch('/api/audits')
+      .then(res => res.json())
+      .then(data => setAudits(data));
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const response = await fetch('/api/audits', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, findings })
+    });
+    if (response.ok) {
+      const newAudit = await response.json();
+      setAudits([...audits, newAudit]);
+      setName('');
+      setFindings('');
+    }
+  };
+
+  return (
+    <div>
+      <h1>Audits</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="Audit Name"
+        />
+        <textarea
+          value={findings}
+          onChange={e => setFindings(e.target.value)}
+          placeholder="Findings"
+        />
+        <button type="submit">Add Audit</button>
+      </form>
+      <ul>
+        {audits.map(audit => (
+          <li key={audit.id}>
+            <strong>{audit.name}</strong>
+            <p>{audit.findings}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AuditForm;

--- a/frontend/src/pages/RiskRegister.tsx
+++ b/frontend/src/pages/RiskRegister.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+
+interface Risk {
+  id: string;
+  title: string;
+  description: string;
+}
+
+const RiskRegister: React.FC = () => {
+  const [risks, setRisks] = useState<Risk[]>([]);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    fetch('/api/risks')
+      .then(res => res.json())
+      .then(data => setRisks(data));
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const response = await fetch('/api/risks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, description })
+    });
+    if (response.ok) {
+      const newRisk = await response.json();
+      setRisks([...risks, newRisk]);
+      setTitle('');
+      setDescription('');
+    }
+  };
+
+  return (
+    <div>
+      <h1>Risk Register</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="Title"
+        />
+        <textarea
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="Description"
+        />
+        <button type="submit">Add Risk</button>
+      </form>
+      <ul>
+        {risks.map(risk => (
+          <li key={risk.id}>
+            <strong>{risk.title}</strong>
+            <p>{risk.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default RiskRegister;


### PR DESCRIPTION
## Summary
- scaffold a placeholder React app for the risk register and audit modules
- add pages to create and view risks and audits

## Testing
- `npm install` *(fails: 403 Forbidden due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6884d45da380832fb3ca123dbe7552c7

## Summary by Sourcery

Add a basic React app skeleton including project setup, entry point, routing, and placeholder pages for managing risks and audits.

New Features:
- Scaffold a React frontend with project structure, dependencies, and entry point configuration
- Implement RiskRegister page with form and list for creating and viewing risks via /api/risks
- Implement AuditForm page with form and list for creating and viewing audits via /api/audits
- Configure client-side routing and navigation between Risk Register and Audits pages