### PR TITLE
Add incident management frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # healthcare-saas-free
 Free serverless SaaS healthcare management system
+
+## Frontend
+A simple React application lives in the `frontend` folder. It provides pages to
+list, create and edit incident records.
+
+### Install dependencies
+```
+cd frontend
+npm install
+```
+
+### Development server
+```
+npm start
+```
+This serves the app on [http://localhost:3000](http://localhost:3000).
+
+### Running tests
+```
+npm test
+```
+This runs Jest unit tests for the React components.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@chakra-ui/react": "^2.8.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.2.1",
+    "@types/jest": "^29.5.12",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.4.5",
+    "webpack": "^5.91.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Incidents</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/bundle.js"></script>
+  </body>
+</html>

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from './App';
+
+test('renders incidents page by default', () => {
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/incidents/i)).toBeInTheDocument();
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import IncidentsPage from './pages/IncidentsPage';
+import IncidentFormPage from './pages/IncidentFormPage';
+
+const App: React.FC = () => (
+  <Router>
+    <Routes>
+      <Route path="/incidents" element={<IncidentsPage />} />
+      <Route path="/incidents/new" element={<IncidentFormPage />} />
+      <Route path="/incidents/:id" element={<IncidentFormPage />} />
+      <Route path="*" element={<IncidentsPage />} />
+    </Routes>
+  </Router>
+);
+
+export default App;

--- a/frontend/src/__tests__/IncidentForm.test.tsx
+++ b/frontend/src/__tests__/IncidentForm.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import IncidentForm from '../components/IncidentForm';
+
+test('renders form title input', () => {
+  render(
+    <MemoryRouter>
+      <IncidentForm />
+    </MemoryRouter>
+  );
+  expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/IncidentList.test.tsx
+++ b/frontend/src/__tests__/IncidentList.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import IncidentList from '../components/IncidentList';
+
+test('renders list header', () => {
+  render(
+    <MemoryRouter>
+      <IncidentList />
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/incidents/i)).toBeInTheDocument();
+});

--- a/frontend/src/api/incidentApi.ts
+++ b/frontend/src/api/incidentApi.ts
@@ -1,0 +1,33 @@
+const API_URL = '/api/incidents';
+
+export async function fetchIncidents() {
+  const res = await fetch(API_URL);
+  if (!res.ok) throw new Error('Failed to fetch incidents');
+  return res.json();
+}
+
+export async function fetchIncident(id: string) {
+  const res = await fetch(`${API_URL}/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch incident');
+  return res.json();
+}
+
+export async function createIncident(data: any) {
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create incident');
+  return res.json();
+}
+
+export async function updateIncident(id: string, data: any) {
+  const res = await fetch(`${API_URL}/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to update incident');
+  return res.json();
+}

--- a/frontend/src/components/IncidentForm.tsx
+++ b/frontend/src/components/IncidentForm.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { createIncident, fetchIncident, updateIncident } from '../api/incidentApi';
+
+const IncidentForm: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    category: '',
+    priority: '',
+    date: '',
+  });
+
+  useEffect(() => {
+    if (id) {
+      fetchIncident(id).then(setForm).catch(console.error);
+    }
+  }, [id]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (id) {
+        await updateIncident(id, form);
+      } else {
+        await createIncident(form);
+      }
+      navigate('/incidents');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Title:
+        <input name="title" value={form.title} onChange={handleChange} required />
+      </label>
+      <label>
+        Description:
+        <textarea name="description" value={form.description} onChange={handleChange} required />
+      </label>
+      <label>
+        Category:
+        <input name="category" value={form.category} onChange={handleChange} />
+      </label>
+      <label>
+        Priority:
+        <select name="priority" value={form.priority} onChange={handleChange}>
+          <option value="">Select</option>
+          <option value="Low">Low</option>
+          <option value="Normal">Normal</option>
+          <option value="High">High</option>
+        </select>
+      </label>
+      <label>
+        Date:
+        <input type="date" name="date" value={form.date} onChange={handleChange} />
+      </label>
+      <button type="submit">{id ? 'Update' : 'Create'}</button>
+    </form>
+  );
+};
+
+export default IncidentForm;

--- a/frontend/src/components/IncidentList.tsx
+++ b/frontend/src/components/IncidentList.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchIncidents } from '../api/incidentApi';
+
+interface Incident {
+  id: string;
+  title: string;
+  category: string;
+  priority: string;
+  date: string;
+}
+
+const IncidentList: React.FC = () => {
+  const [incidents, setIncidents] = useState<Incident[]>([]);
+
+  useEffect(() => {
+    fetchIncidents().then(setIncidents).catch(console.error);
+  }, []);
+
+  return (
+    <div>
+      <h2>Incidents</h2>
+      <Link to="/incidents/new">Create New Incident</Link>
+      <ul>
+        {incidents.map(inc => (
+          <li key={inc.id}>
+            <Link to={`/incidents/${inc.id}`}>{inc.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default IncidentList;

--- a/frontend/src/components/IncidentList.tsx
+++ b/frontend/src/components/IncidentList.tsx
@@ -21,13 +21,17 @@ const IncidentList: React.FC = () => {
     <div>
       <h2>Incidents</h2>
       <Link to="/incidents/new">Create New Incident</Link>
-      <ul>
-        {incidents.map(inc => (
-          <li key={inc.id}>
-            <Link to={`/incidents/${inc.id}`}>{inc.title}</Link>
-          </li>
-        ))}
-      </ul>
+      {incidents.length === 0 ? (
+        <p>No incidents found.</p>
+      ) : (
+        <ul>
+          {incidents.map(inc => (
+            <li key={inc.id}>
+              <Link to={`/incidents/${inc.id}`}>{inc.title}</Link>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/IncidentFormPage.tsx
+++ b/frontend/src/pages/IncidentFormPage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import IncidentForm from '../components/IncidentForm';
+
+const IncidentFormPage: React.FC = () => <IncidentForm />;
+
+export default IncidentFormPage;

--- a/frontend/src/pages/IncidentsPage.tsx
+++ b/frontend/src/pages/IncidentsPage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import IncidentList from '../components/IncidentList';
+
+const IncidentsPage: React.FC = () => <IncidentList />;
+
+export default IncidentsPage;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/',
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  devServer: {
+    static: path.join(__dirname, 'public'),
+    historyApiFallback: true,
+    port: 3000,
+  },
+};


### PR DESCRIPTION
## Summary
- create React frontend for incident management under `frontend`
- add components for listing and editing incidents
- configure Webpack and TypeScript
- add sample Jest unit tests
- document how to run and test the frontend in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884e6c94bd0832f850d028cb68e502a

## Summary by Sourcery

Add a new React-based incident management frontend with list and form components, setup build tooling, testing, and documentation.

New Features:
- Add React app under frontend for incident management
- Implement IncidentList and IncidentForm components with CRUD API integration and routing

Build:
- Configure Webpack and TypeScript for frontend bundling
- Add npm scripts for start, build, and test in frontend package.json

Documentation:
- Document frontend setup, development server, and testing in project README

Tests:
- Add Jest and React Testing Library tests for IncidentList and IncidentForm components