### PR TITLE
Address form feedback

### DIFF
--- a/frontend/src/components/AuditForm.tsx
+++ b/frontend/src/components/AuditForm.tsx
@@ -31,6 +31,7 @@ const AuditForm: React.FC = () => {
       } else {
         await createForm(payload);
       }
+      setForm({ name: '', questions: '' });
       navigate('/audits');
     } catch (err) {
       console.error(err);

--- a/frontend/src/components/Field.tsx
+++ b/frontend/src/components/Field.tsx
@@ -1,0 +1,17 @@
+import React, { ReactNode } from 'react';
+
+interface FieldProps {
+  id: string;
+  label: string;
+  isRequired?: boolean;
+  children: ReactNode;
+}
+
+const Field: React.FC<FieldProps> = ({ id, label, isRequired = false, children }) => (
+  <div>
+    <label htmlFor={id}>{label}</label>
+    {children}
+  </div>
+);
+
+export default Field;

--- a/frontend/src/components/IncidentForm.tsx
+++ b/frontend/src/components/IncidentForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { createIncident, fetchIncident, updateIncident } from '../api/incidentApi';
+import Field from './Field';
 
 const IncidentForm: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -13,6 +14,7 @@ const IncidentForm: React.FC = () => {
     priority: '',
     date: '',
   });
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -26,6 +28,7 @@ const IncidentForm: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setSubmitting(true);
     try {
       if (id) {
         await updateIncident(id, form);
@@ -35,37 +38,62 @@ const IncidentForm: React.FC = () => {
       navigate('/incidents');
     } catch (err) {
       console.error(err);
+    } finally {
+      setSubmitting(false);
     }
   };
 
-  return (
-    <form onSubmit={handleSubmit}>
-      <label>
-        Title:
-        <input name="title" value={form.title} onChange={handleChange} required />
-      </label>
-      <label>
-        Description:
-        <textarea name="description" value={form.description} onChange={handleChange} required />
-      </label>
-      <label>
-        Category:
-        <input name="category" value={form.category} onChange={handleChange} />
-      </label>
-      <label>
-        Priority:
-        <select name="priority" value={form.priority} onChange={handleChange}>
+  const fields = [
+    {
+      id: 'title',
+      label: 'Title',
+      element: (
+        <input id="title" name="title" value={form.title} onChange={handleChange} required />
+      )
+    },
+    {
+      id: 'description',
+      label: 'Description',
+      element: (
+        <textarea id="description" name="description" value={form.description} onChange={handleChange} required />
+      )
+    },
+    {
+      id: 'category',
+      label: 'Category',
+      element: (
+        <input id="category" name="category" value={form.category} onChange={handleChange} />
+      )
+    },
+    {
+      id: 'priority',
+      label: 'Priority',
+      element: (
+        <select id="priority" name="priority" value={form.priority} onChange={handleChange}>
           <option value="">Select</option>
           <option value="Low">Low</option>
           <option value="Normal">Normal</option>
           <option value="High">High</option>
         </select>
-      </label>
-      <label>
-        Date:
-        <input type="date" name="date" value={form.date} onChange={handleChange} />
-      </label>
-      <button type="submit">{id ? 'Update' : 'Create'}</button>
+      )
+    },
+    {
+      id: 'date',
+      label: 'Date',
+      element: (
+        <input id="date" type="date" name="date" value={form.date} onChange={handleChange} />
+      )
+    }
+  ];
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {fields.map(f => (
+        <Field key={f.id} id={f.id} label={f.label}>
+          {f.element}
+        </Field>
+      ))}
+      <button type="submit" disabled={submitting}>{id ? 'Update' : 'Create'}</button>
     </form>
   );
 };

--- a/frontend/src/components/IncidentList.tsx
+++ b/frontend/src/components/IncidentList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
+import { Link as ChakraLink } from '@chakra-ui/react';
 import { fetchIncidents } from '../api/incidentApi';
 
 interface Incident {
@@ -20,14 +21,14 @@ const IncidentList: React.FC = () => {
   return (
     <div>
       <h2>Incidents</h2>
-      <Link to="/incidents/new">Create New Incident</Link>
+      <ChakraLink as={RouterLink} to="/incidents/new">Create New Incident</ChakraLink>
       {incidents.length === 0 ? (
         <p>No incidents found.</p>
       ) : (
         <ul>
           {incidents.map(inc => (
             <li key={inc.id}>
-              <Link to={`/incidents/${inc.id}`}>{inc.title}</Link>
+              <ChakraLink as={RouterLink} to={`/incidents/${inc.id}`}>{inc.title}</ChakraLink>
             </li>
           ))}
         </ul>

--- a/frontend/src/components/RiskForm.tsx
+++ b/frontend/src/components/RiskForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { createRisk, fetchRisk, updateRisk } from '../api/riskApi';
+import Field from './Field';
 
 const RiskForm: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -12,6 +13,7 @@ const RiskForm: React.FC = () => {
     impact: '',
     status: ''
   });
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -26,6 +28,7 @@ const RiskForm: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!form.description) return;
+    setSubmitting(true);
     try {
       if (id) {
         await updateRisk(id, form);
@@ -35,28 +38,50 @@ const RiskForm: React.FC = () => {
       navigate('/risks');
     } catch (err) {
       console.error(err);
+    } finally {
+      setSubmitting(false);
     }
   };
 
+  const fields = [
+    {
+      id: 'description',
+      label: 'Description',
+      element: (
+        <input id="description" name="description" value={form.description} onChange={handleChange} required />
+      )
+    },
+    {
+      id: 'likelihood',
+      label: 'Likelihood',
+      element: (
+        <input id="likelihood" name="likelihood" type="number" value={form.likelihood} onChange={handleChange} required />
+      )
+    },
+    {
+      id: 'impact',
+      label: 'Impact',
+      element: (
+        <input id="impact" name="impact" type="number" value={form.impact} onChange={handleChange} required />
+      )
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      element: (
+        <input id="status" name="status" value={form.status} onChange={handleChange} />
+      )
+    }
+  ];
+
   return (
     <form onSubmit={handleSubmit}>
-      <label>
-        Description:
-        <input name="description" value={form.description} onChange={handleChange} required />
-      </label>
-      <label>
-        Likelihood:
-        <input name="likelihood" type="number" value={form.likelihood} onChange={handleChange} required />
-      </label>
-      <label>
-        Impact:
-        <input name="impact" type="number" value={form.impact} onChange={handleChange} required />
-      </label>
-      <label>
-        Status:
-        <input name="status" value={form.status} onChange={handleChange} />
-      </label>
-      <button type="submit">{id ? 'Update' : 'Create'}</button>
+      {fields.map(f => (
+        <Field key={f.id} id={f.id} label={f.label}>
+          {f.element}
+        </Field>
+      ))}
+      <button type="submit" disabled={submitting}>{id ? 'Update' : 'Create'}</button>
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- add generic `Field` component
- refactor `IncidentForm` to use mapped fields and disable submit while submitting
- clear audit form after submission
- use Chakra `Link` in `IncidentList`
- refactor `RiskForm` to map fields and disable submit while submitting

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden when attempting to download jest)*

------
https://chatgpt.com/codex/tasks/task_e_68894f1745d8832f9a87d4e09194eeab

## Summary by Sourcery

Introduce a reusable Field component and refactor existing forms to leverage it while improving UX with submit-disabled states and clearing form data upon submission, and update IncidentList to use Chakra UI links

New Features:
- Introduce a generic Field component for consistent form layout

Enhancements:
- Refactor IncidentForm and RiskForm to map fields through the Field component
- Disable submit buttons while IncidentForm and RiskForm are submitting
- Clear AuditForm inputs after successful submission
- Replace react-router Link with Chakra UI Link in IncidentList