### PR TITLE
Add frontend deployment to Cloudflare Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,26 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: healthcare-saas-frontend
+          directory: frontend/dist

--- a/README.md
+++ b/README.md
@@ -88,3 +88,11 @@ To enable deployments, configure the following repository secrets:
 - `CLOUDFLARE_ACCOUNT_ID` – your Cloudflare account ID.
 
 Once the secrets are added, pushing to `main` will automatically run tests and deploy the worker.
+
+### Cloudflare Pages
+
+The React frontend is deployed using [Cloudflare Pages](https://pages.cloudflare.com/). The
+`Deploy Frontend` workflow builds the app from `frontend/` and publishes the contents of
+`frontend/dist` whenever changes land on `main`. Configure the same `CLOUDFLARE_API_TOKEN`
+and `CLOUDFLARE_ACCOUNT_ID` secrets and create a Pages project named
+`healthcare-saas-frontend` in your account.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "typescript": "^5.4.5",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1"
+    "webpack-dev-server": "^4.15.1",
+    "html-webpack-plugin": "^5.5.0"
   }
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-
 import { createRoot } from 'react-dom/client';
-import App from './App';
 import { BrowserRouter } from 'react-router-dom';
+import App from './App';
 
 const container = document.getElementById('root');
 if (container) {

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   entry: './src/index.tsx',
@@ -19,6 +20,11 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, 'public', 'index.html'),
+    }),
+  ],
   devServer: {
     static: path.join(__dirname, 'public'),
     historyApiFallback: true,


### PR DESCRIPTION
## Summary
- fix duplicate imports in frontend entrypoint
- generate index.html during Webpack build
- include HtmlWebpackPlugin in dependencies
- add GitHub Actions workflow to deploy frontend to Cloudflare Pages
- document Pages deployment in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68894fd58dec832fb0f7cba432708313

## Summary by Sourcery

Setup automated deployment of the React frontend to Cloudflare Pages by integrating HtmlWebpackPlugin, cleaning up entrypoint imports, adding a GitHub Actions workflow, and updating documentation.

New Features:
- Add GitHub Actions workflow to deploy the frontend to Cloudflare Pages on pushes to main
- Integrate HtmlWebpackPlugin in Webpack configuration to generate index.html during builds

Bug Fixes:
- Remove duplicate ReactDOM imports in frontend entrypoint

Enhancements:
- Add html-webpack-plugin as a frontend dependency

CI:
- Add pages.yml workflow for building and deploying the frontend to Cloudflare Pages

Documentation:
- Document Cloudflare Pages deployment steps in README