### PR TITLE
Fix Authorization header parsing

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -1,5 +1,15 @@
+function extractBearerToken(request) {
+  const authHeader = request.headers.get('Authorization') || '';
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
 export default {
   async fetch(request, env) {
+    const token = extractBearerToken(request);
+    if (!token) {
+      return new Response('Unauthorized', { status: 401 });
+    }
     return new Response('Healthcare SaaS API');
   },
 };


### PR DESCRIPTION
## Summary
- guard against malformed `Authorization` headers

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889c0dbdd14832fa7cd05f3381365e8