### PR TITLE
Fix Base64Url decoding for JWTs

### DIFF
--- a/src/utils/base64url.js
+++ b/src/utils/base64url.js
@@ -1,0 +1,10 @@
+export function decodeBase64Url(input) {
+  if (typeof input !== 'string') {
+    throw new TypeError('Expected a string');
+  }
+  let normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  while (normalized.length % 4 !== 0) {
+    normalized += '=';
+  }
+  return Buffer.from(normalized, 'base64');
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,13 @@
 import assert from 'assert';
+import { decodeBase64Url } from '../src/utils/base64url.js';
 
 assert.strictEqual(1 + 1, 2);
+
+// should decode standard base64url string
+assert.strictEqual(decodeBase64Url('eyJmb28iOiJiYXIifQ').toString(), '{"foo":"bar"}');
+
+// should handle url safe characters and padding
+assert.deepStrictEqual(decodeBase64Url('-A'), Buffer.from([248]));
+assert.deepStrictEqual(decodeBase64Url('__8'), Buffer.from([255, 255]));
+
 console.log('Tests passed');


### PR DESCRIPTION
## Summary
- add helper `decodeBase64Url` for URL-safe Base64
- extend tests to cover Base64Url decoding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889c0e73160832fa5e70b2204824753

## Summary by Sourcery

Provide a utility to decode URL-safe Base64 strings and add corresponding tests

New Features:
- Add decodeBase64Url helper for URL-safe Base64 decoding

Tests:
- Extend tests to cover Base64Url decoding