### PR TITLE
Use CommonJS for Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "healthcare-saas-free",
   "version": "1.0.0",
-  "type": "module",
+  "type": "commonjs",
   "scripts": {
     "test": "node tests/test.js"
   }

--- a/src/utils/base64url.js
+++ b/src/utils/base64url.js
@@ -1,4 +1,4 @@
-export function decodeBase64Url(input) {
+function decodeBase64Url(input) {
   if (typeof input !== 'string') {
     throw new TypeError('Expected a string');
   }
@@ -8,3 +8,5 @@ export function decodeBase64Url(input) {
   }
   return Buffer.from(normalized, 'base64');
 }
+
+module.exports = { decodeBase64Url };

--- a/tests/riskHandlers.test.js
+++ b/tests/riskHandlers.test.js
@@ -8,6 +8,8 @@ const { createRisk } = require('../handlers/createRisk');
 const { updateRisk } = require('../handlers/updateRisk');
 const { getRisk } = require('../handlers/getRisk');
 
+const token = 'e30=.eyJyb2xlcyI6WyJhZG1pbiIsInN0YWZmIl19.sig';
+
 let tempDb;
 
 beforeEach(() => {
@@ -24,7 +26,10 @@ afterEach(() => {
 });
 
 test('createRisk returns new risk', async () => {
-  const event = { body: JSON.stringify({ description: 'New risk', likelihood: 2, impact: 3, status: 'open' }) };
+  const event = { 
+    body: JSON.stringify({ description: 'New risk', likelihood: 2, impact: 3, status: 'open' }),
+    headers: { Authorization: `Bearer ${token}` }
+  };
   const res = await createRisk(event);
   assert.strictEqual(res.statusCode, 201);
   const risk = JSON.parse(res.body);
@@ -33,10 +38,17 @@ test('createRisk returns new risk', async () => {
 });
 
 test('updateRisk modifies existing risk', async () => {
-  const createEvent = { body: JSON.stringify({ description: 'Risk', likelihood: 1, impact: 1, status: 'open' }) };
+  const createEvent = { 
+    body: JSON.stringify({ description: 'Risk', likelihood: 1, impact: 1, status: 'open' }),
+    headers: { Authorization: `Bearer ${token}` }
+  };
   const created = await createRisk(createEvent);
   const risk = JSON.parse(created.body);
-  const updateEvent = { pathParameters: { riskId: risk.riskId }, body: JSON.stringify({ status: 'closed' }) };
+  const updateEvent = { 
+    pathParameters: { riskId: risk.riskId }, 
+    body: JSON.stringify({ status: 'closed' }),
+    headers: { Authorization: `Bearer ${token}` }
+  };
   const res = await updateRisk(updateEvent);
   assert.strictEqual(res.statusCode, 200);
   const updated = JSON.parse(res.body);
@@ -44,10 +56,16 @@ test('updateRisk modifies existing risk', async () => {
 });
 
 test('getRisk retrieves a risk by id', async () => {
-  const createEvent = { body: JSON.stringify({ description: 'Another', likelihood: 1, impact: 1, status: 'open' }) };
+  const createEvent = { 
+    body: JSON.stringify({ description: 'Another', likelihood: 1, impact: 1, status: 'open' }),
+    headers: { Authorization: `Bearer ${token}` }
+  };
   const created = await createRisk(createEvent);
   const risk = JSON.parse(created.body);
-  const getEvent = { pathParameters: { riskId: risk.riskId } };
+  const getEvent = { 
+    pathParameters: { riskId: risk.riskId },
+    headers: { Authorization: `Bearer ${token}` }
+  };
   const res = await getRisk(getEvent);
   assert.strictEqual(res.statusCode, 200);
   const fetched = JSON.parse(res.body);

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,5 +1,5 @@
-import assert from 'assert';
-import { decodeBase64Url } from '../src/utils/base64url.js';
+const assert = require('assert');
+const { decodeBase64Url } = require('../src/utils/base64url.js');
 
 assert.strictEqual(1 + 1, 2);
 


### PR DESCRIPTION
## Summary
- switch Node environment to CommonJS
- convert utilities and tests to CommonJS syntax
- update risk handler tests to supply an auth token

## Testing
- `npm test`
- `node tests/riskHandlers.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6889c54b55dc832f9d0570e14a6bd881

## Summary by Sourcery

Switch the Node environment to CommonJS and update code and tests accordingly

Enhancements:
- Convert utility modules to CommonJS syntax

Build:
- Set package.json "type" field to "commonjs"

Tests:
- Convert test files to CommonJS syntax
- Include Authorization tokens in risk handler test events