### PR TITLE
Add Node and frontend test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           node-version: '18'
       - run: npm install
+      - run: npm install --prefix frontend
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "healthcare-saas-free",
   "version": "1.0.0",
-  "type": "module",
   "scripts": {
-    "test": "node tests/test.js"
+    "test": "npm run test:node && npm run test:frontend",
+    "test:node": "node --test --test-concurrency=1 tests/riskHandlers.test.cjs && node tests/test.js",
+    "test:frontend": "npm --prefix frontend test"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   async fetch(request) {
     return new Response('Hello from Healthcare SaaS Free!', {
       headers: { 'Content-Type': 'text/plain' }

--- a/src/utils/base64url.js
+++ b/src/utils/base64url.js
@@ -1,4 +1,4 @@
-export function decodeBase64Url(input) {
+function decodeBase64Url(input) {
   if (typeof input !== 'string') {
     throw new TypeError('Expected a string');
   }
@@ -8,3 +8,5 @@ export function decodeBase64Url(input) {
   }
   return Buffer.from(normalized, 'base64');
 }
+
+module.exports = { decodeBase64Url };

--- a/tests/riskHandlers.test.cjs
+++ b/tests/riskHandlers.test.cjs
@@ -4,9 +4,11 @@ const path = require('path');
 const { test, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 
-const { createRisk } = require('../handlers/createRisk');
-const { updateRisk } = require('../handlers/updateRisk');
-const { getRisk } = require('../handlers/getRisk');
+const auth = require('../auth');
+
+let originalRequireRole;
+
+let createRisk, updateRisk, getRisk;
 
 let tempDb;
 
@@ -15,12 +17,29 @@ beforeEach(() => {
   tempDb = path.join(dir, 'db.json');
   fs.writeFileSync(tempDb, '[]');
   process.env.RISK_DB = tempDb;
+  process.env.SKIP_AUTH = 'true';
+  originalRequireRole = auth.requireRole;
+  auth.requireRole = () => {};
+  delete require.cache[require.resolve('../riskData')];
+  const riskData = require('../riskData');
+  delete require.cache[require.resolve('../handlers/createRisk')];
+  delete require.cache[require.resolve('../handlers/updateRisk')];
+  delete require.cache[require.resolve('../handlers/getRisk')];
+  createRisk = require('../handlers/createRisk').createRisk;
+  updateRisk = require('../handlers/updateRisk').updateRisk;
+  getRisk = require('../handlers/getRisk').getRisk;
 });
 
 afterEach(() => {
   fs.unlinkSync(tempDb);
   fs.rmdirSync(path.dirname(tempDb));
   delete process.env.RISK_DB;
+  delete process.env.SKIP_AUTH;
+  auth.requireRole = originalRequireRole;
+  delete require.cache[require.resolve('../riskData')];
+  delete require.cache[require.resolve('../handlers/createRisk')];
+  delete require.cache[require.resolve('../handlers/updateRisk')];
+  delete require.cache[require.resolve('../handlers/getRisk')];
 });
 
 test('createRisk returns new risk', async () => {
@@ -30,7 +49,7 @@ test('createRisk returns new risk', async () => {
   const risk = JSON.parse(res.body);
   assert.ok(risk.riskId);
   assert.strictEqual(risk.description, 'New risk');
-});
+}, { concurrency: false });
 
 test('updateRisk modifies existing risk', async () => {
   const createEvent = { body: JSON.stringify({ description: 'Risk', likelihood: 1, impact: 1, status: 'open' }) };
@@ -41,7 +60,7 @@ test('updateRisk modifies existing risk', async () => {
   assert.strictEqual(res.statusCode, 200);
   const updated = JSON.parse(res.body);
   assert.strictEqual(updated.status, 'closed');
-});
+}, { concurrency: false });
 
 test('getRisk retrieves a risk by id', async () => {
   const createEvent = { body: JSON.stringify({ description: 'Another', likelihood: 1, impact: 1, status: 'open' }) };
@@ -52,4 +71,4 @@ test('getRisk retrieves a risk by id', async () => {
   assert.strictEqual(res.statusCode, 200);
   const fetched = JSON.parse(res.body);
   assert.strictEqual(fetched.riskId, risk.riskId);
-});
+}, { concurrency: false });

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,5 +1,5 @@
-import assert from 'assert';
-import { decodeBase64Url } from '../src/utils/base64url.js';
+const assert = require('assert');
+const { decodeBase64Url } = require('../src/utils/base64url.js');
 
 assert.strictEqual(1 + 1, 2);
 


### PR DESCRIPTION
## Summary
- enable tests for both backend and frontend
- switch modules to CommonJS for compatibility
- update test workflow to install frontend deps

## Testing
- `npm install` *(fails: `npm install --prefix frontend` 403 Forbidden)*
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6889c55d8810832fa956e6104645ebff

## Summary by Sourcery

Enable unified testing for Node backend and frontend by converting modules to CommonJS and updating test scripts and workflows.

New Features:
- Add frontend test runner integrated into the npm test script

Enhancements:
- Migrate project files and utilities to CommonJS for compatibility with Node.js test runner
- Configure risk handler tests to mock authentication and disable concurrency
- Update package.json with separate scripts for Node and frontend testing

CI:
- Install frontend dependencies in GitHub Actions before running tests

Tests:
- Convert riskHandlers tests to .cjs with setup/teardown auth mocking and concurrency control
- Refactor base64url utility and test file to use require syntax