### PR TITLE
Ensure audit data directory exists automatically

### DIFF
--- a/audit/package.json
+++ b/audit/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/audit/src/storage.js
+++ b/audit/src/storage.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 const dataDir = path.join(__dirname, '..', 'data');
+// Ensure the data directory exists so tests and handlers can write files
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir, { recursive: true });
+}
 const formsFile = path.join(dataDir, 'forms.json');
 const resultsFile = path.join(dataDir, 'results.json');
 const offlineFile = path.join(dataDir, 'offlineResults.json');

--- a/audit/test/package.json
+++ b/audit/test/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- create audit data directory automatically
- mark audit folders as CommonJS so tests run

## Testing
- `node tests/test.js`
- `node audit/test/run-tests.js`
- `python3 tests/test_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_6889c5538154832f8de1f4573e9dd7ae

## Summary by Sourcery

Ensure the audit data directory is automatically created and configure audit packages as CommonJS to support tests

Enhancements:
- Automatically create the audit data directory if it does not exist
- Mark audit and audit test packages as CommonJS modules to allow tests to run