### PR TITLE
Add UML for risk register module

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Unit tests can be run with:
 npm test
 ```
 
+### UML Diagram
+
+The relationships between the risk register handlers, authentication helper and
+data access utilities are documented in `docs/risk_register.puml`. Render this
+file with [PlantUML](https://plantuml.com/) to view the diagram.
+
 ### Running the React UI
 
 The client application lives in `frontend/`:

--- a/docs/risk_register.puml
+++ b/docs/risk_register.puml
@@ -1,0 +1,35 @@
+@startuml
+' UML diagram for risk_register module
+class RiskData {
+  +readRisks()
+  +writeRisks(risks)
+  +DB_FILE : string
+}
+
+class Auth {
+  +getUser(event)
+  +requireRole(event, role)
+}
+
+class CreateRiskHandler {
+  +createRisk(event)
+}
+class UpdateRiskHandler {
+  +updateRisk(event)
+}
+class GetRiskHandler {
+  +getRisk(event)
+}
+class ListRisksHandler {
+  +listRisks(event)
+}
+
+RiskData <.. CreateRiskHandler
+RiskData <.. UpdateRiskHandler
+RiskData <.. GetRiskHandler
+RiskData <.. ListRisksHandler
+Auth <.. CreateRiskHandler
+Auth <.. UpdateRiskHandler
+Auth <.. GetRiskHandler
+Auth <.. ListRisksHandler
+@enduml


### PR DESCRIPTION
## Summary
- document the relationships between risk register handlers
- provide PlantUML diagram in `docs/`
- reference the diagram from the README

## Testing
- `npm test`
- `node tests/riskHandlers.test.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889ced43e38832fa5353bd7958f4a12

## Summary by Sourcery

Add a PlantUML diagram for the risk register module and reference it in the project documentation.

Documentation:
- Introduce docs/risk_register.puml to illustrate relationships among risk handlers, authentication helper, and data utilities
- Update README to include a UML Diagram section pointing to the new PlantUML file